### PR TITLE
Do we need to keep 21 instead of 20 frames?

### DIFF
--- a/industry_benchmarks/utils/tests/test_traj_cleanup.py
+++ b/industry_benchmarks/utils/tests/test_traj_cleanup.py
@@ -63,5 +63,5 @@ def test_extract_data(simulation, checkpoint, pdb, outfile, tmp_path):
         traj = pathlib.Path(f'{out_traj}_{i}.xtc')
         assert traj.is_file()
         u = mda.Universe(pdb, traj)
-        # Check that we saved 20 frames
-        assert len(u.trajectory) == 20
+        # Check that we saved 21 frames
+        assert len(u.trajectory) == 21

--- a/industry_benchmarks/utils/tests/test_traj_cleanup.py
+++ b/industry_benchmarks/utils/tests/test_traj_cleanup.py
@@ -63,5 +63,8 @@ def test_extract_data(simulation, checkpoint, pdb, outfile, tmp_path):
         traj = pathlib.Path(f'{out_traj}_{i}.xtc')
         assert traj.is_file()
         u = mda.Universe(pdb, traj)
+        times = [round(i) for i in np.linspace(0, 250, 21)]
+        for ts, time in zip(u.trajectory, times):
+            assert ts.time == time
         # Check that we saved 21 frames
         assert len(u.trajectory) == 21

--- a/industry_benchmarks/utils/traj_cleanup.py
+++ b/industry_benchmarks/utils/traj_cleanup.py
@@ -31,7 +31,7 @@ def subsample_traj(simulation, hybrid_system_pdb, lambda_windows, outfile):
     for i in range(0, lambda_windows):
         u = mda.Universe(hybrid_system_pdb, simulation,
                          format=FEReader, state_id=i)
-        skip = round(len(u.trajectory) / 20)
+        skip = round(len(u.trajectory) / 21)
         out_traj = pathlib.Path(f'{outfile}_{i}.xtc')
         with mda.Writer(str(out_traj), n_atoms=len(u.atoms)) as w:
             for ts in u.trajectory[::skip]:

--- a/industry_benchmarks/utils/traj_cleanup.py
+++ b/industry_benchmarks/utils/traj_cleanup.py
@@ -31,14 +31,11 @@ def subsample_traj(simulation, hybrid_system_pdb, lambda_windows, outfile):
     for i in range(0, lambda_windows):
         u = mda.Universe(hybrid_system_pdb, simulation,
                          format=FEReader, state_id=i)
-        skip = round(len(u.trajectory) / 20)
+        frames = [round(i) for i in np.linspace(0, len(u.trajectory)-1, 21)]
         out_traj = pathlib.Path(f'{outfile}_{i}.xtc')
         with mda.Writer(str(out_traj), n_atoms=len(u.atoms)) as w:
-            for ts in u.trajectory[::skip]:
+            for ts in u.trajectory[frames]:
                 w.write(u.atoms)
-            # write out the final frame too
-            u.trajectory[-1]
-            w.write(u.atoms)
             
 
 def extract_data(simulation, checkpoint, hybrid_pdb, outfile, out_traj='out'):

--- a/industry_benchmarks/utils/traj_cleanup.py
+++ b/industry_benchmarks/utils/traj_cleanup.py
@@ -31,12 +31,15 @@ def subsample_traj(simulation, hybrid_system_pdb, lambda_windows, outfile):
     for i in range(0, lambda_windows):
         u = mda.Universe(hybrid_system_pdb, simulation,
                          format=FEReader, state_id=i)
-        skip = round(len(u.trajectory) / 21)
+        skip = round(len(u.trajectory) / 20)
         out_traj = pathlib.Path(f'{outfile}_{i}.xtc')
         with mda.Writer(str(out_traj), n_atoms=len(u.atoms)) as w:
             for ts in u.trajectory[::skip]:
                 w.write(u.atoms)
-
+            # write out the final frame too
+            u.trajectory[-1]
+            w.write(u.atoms)
+            
 
 def extract_data(simulation, checkpoint, hybrid_pdb, outfile, out_traj='out'):
     """


### PR DESCRIPTION
Fixes #63 

@hannahbaumann I'm writing the data retention policy and I wanted to check something - do we need to keep 20 frames or 21?

Rough thinking: "we need to keep both the first and last frame"

For a 5 ns trajectory that would be:

0, 0.25, 0.5, 0.75, 1 (5 frames)
1.25, 1.5, 1.75, 2 (4 frames)
.. 3 (4 frames)
.. 4 (4 frames)
.. 5 (4 frames)

Totalling 21 frames?

Similarly for a 20 ns trajectory sampling every 1 ns, that should be 21 frames right?