### PR TITLE
Updated installation instructions

### DIFF
--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -54,6 +54,10 @@ For additional details, please visit the `Installation page <https://docs.openfr
 Single file installer
 =====================
 
+.. warning::
+
+   The single file installer may modify your ``.bashrc`` in a way that requires manual intervention to access your previous ``conda`` installation 
+
 .. _releases on GitHub: https://github.com/OpenFreeEnergy/openfe/releases
 
 Single file installers are available for x86_64 Linux and MacOS.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -36,7 +36,7 @@ The `conda-lock` file for OpenFE version v1.0.1 can be downloaded with ::
 .. note::
 
    You will likely need to install ``conda-lock``.
-   We recommend installing ``conda-lock`` in a new virtual environment.
+   We recommend installing ``conda-lock`` in a new virtual environment using either `conda` or `mamba`.
    This will reduce the chance of dependency conflicts ::
 
        $ # Install conda lock into a virtual environment

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -5,7 +5,51 @@ The page has information for installing ``openfe``, and testing that your ``open
 
 For this benchmarking study, we would like to ask that all participants use a specific installation of OpenFE (v1.0.1) alongside selected pinned tooling dependencies (e.g. openff-toolkit v0.15.2, openmm v8.1.1, openmmforcefields v0.13.0, openmmtools v0.23.1).
 
-To do this, we ask participants to install a version of openfe with a pre-defined environment. This can be achieved in two different ways, using a single file installer or a conda lock file, as described below.
+To do this, we ask participants to install a version of openfe with a pre-defined environment. 
+This can be achieved in two different ways, using a conda lock file or a single file installer as described below.
+
+.. note::
+
+   We recommend using a ``conda-lock`` file unless you are unable to download packages.
+   The error may look something like this ::
+
+       ERROR:root:Retrying (Retry(total=2, connect=None, read=None, redirect=None, status=None)) after connection broken by 'NameResolutionError("<urllib3.connection.HTTPSConnection object at 0x7bc5c3e75670>: Failed to resolve 'conda.anaconda.org' ([Errno -2] Name or service not known)")'
+
+   Only then should you use the single file installer
+
+
+``conda-lock`` file
+===================
+
+.. _conda-lock: https://github.com/conda/conda-lock?tab=readme-ov-file#conda-lock
+
+A `conda-lock`_ file is a cross platform way of specifying a conda environment that specifies packages in a reproducible way.
+Unlike the single file installer, an internet connection is required to install from a ``conda-lock`` file.
+We recommend the use of a ``conda-lock`` file when the same conda environment is required across different systems.
+
+See https://github.com/conda/conda-lock?tab=readme-ov-file#conda-lock for more information on ``conda-lock``.
+
+The `conda-lock` file for OpenFE version v1.0.1 can be downloaded with ::
+
+  $ curl -LOJ https://github.com/OpenFreeEnergy/openfe/releases/download/v1.0.1/conda-lock-openfe-1.0.1.yml
+
+.. note::
+
+   You will likely need to install ``conda-lock``.
+   We recommend installing ``conda-lock`` in a new virtual environment.
+   This will reduce the chance of dependency conflicts ::
+
+       $ # Install conda lock into a virtual environment
+       $ conda create -n conda-lock -c conda-lock
+       $ # Activate the environment to use the conda-lock command
+       $ conda activate conda-lock
+
+Create a conda environment from the lock file and activate it::
+
+  $ conda-lock install -n openfe conda-lock-openfe-1.0.1.yml
+  $ conda activate openfe
+
+For additional details, please visit the `Installation page <https://docs.openfree.energy/en/latest/installation.html>`_ in the OpenFE documentation.
 
 Single file installer
 =====================
@@ -42,32 +86,6 @@ To check if your path is setup correctly, run ``which python`` your output shoul
 
 .. note::
    Your path will be different, but the important part is ``openfeforge/bin/python``
-
-For additional details, please visit the `Installation page <https://docs.openfree.energy/en/latest/installation.html>`_ in the OpenFE documentation.
-
-``conda-lock`` file
-===================
-
-.. _conda-lock: https://github.com/conda/conda-lock?tab=readme-ov-file#conda-lock
-
-A `conda-lock`_ file is a cross platform way of specifying a conda environment that specifies packages in a reproducible way.
-Unlike the single file installer, an internet connection is required to install from a ``conda-lock`` file.
-We recomend the use of a ``conda-lock`` file when the same conda environment is required across different systems.
-
-See https://github.com/conda/conda-lock?tab=readme-ov-file#installation for instructions on how to install ``conda-lock``.
-
-.. note::
-
-   You will likely need to install ``conda-lock``
-
-The `conda-lock` file for OpenFE version v1.0.1 can be downloaded with ::
-
-  $ curl -LOJ https://github.com/OpenFreeEnergy/openfe/releases/download/v1.0.1/conda-lock-openfe-1.0.1.yml
-
-Create a conda environment from the lock file and activate it::
-
-  $ conda-lock install -n openfe conda-lock-openfe-1.0.1.yml
-  $ conda activate openfe
 
 For additional details, please visit the `Installation page <https://docs.openfree.energy/en/latest/installation.html>`_ in the OpenFE documentation.
 


### PR DESCRIPTION
Made it clear to use the lock file and to only use the single file installer if needed. Also made it more clear how to install conda-lock as well

<!--
Thank you for opening a contribution to the OpenFE 2024 industry benchmark repository.
Below are a few things we ask you to kindly fill in and self-check before we
can accept your contribution. Please ignore any irrelevant sections.
-->

## Input submission checklist

<!--
If you are submitting prepared input files please indicate if you have
done the following:
-->

* [ ] created a directory for each system based on the [template directory][templates]
* [ ] named and placed the directory with the following pattern: `input_structures/prepared_structures/<set_name>/<system_name>`

For each submitted directory:

* [ ] filled in system preparation details in the `PREPARATION_DETAILS.md` file
* [ ] added a PDB file with the protein named `protein.pdb`
* [ ] removed any cofactors from the PDB file and placed them in `cofactors.sdf`
* [ ] kept cystallographic waters and metals in the PDB file
* [ ] tested the PDB and, if available, cofactors.sdf file using the [input validation script][input_validation]
* [ ] copied over the ligands SDF file to a file named `ligands.sdf` and removed any duplicate binding modes or protonation states, keeping the more favorable state

<!--
Here please add a summary of what changes you have made
-->
## Summary of changes

<!--
Also please indicate that you are happy to release these materials under the
combined MIT and CCBY-SA 4.0 licenses of this repository
-->
## Licensing agreement
* [ ] I agree to release these inputs under the combined MIT and CCBY SA 4.0 licenses of this repository

[templates]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks
[input_validation]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks/utils/input_validation.py
