### PR TITLE
Add some debug information to help when things fail

### DIFF
--- a/industry_benchmarks/utils/extras/extract_results.py
+++ b/industry_benchmarks/utils/extras/extract_results.py
@@ -9,7 +9,13 @@ import csv
 
 def get_names(result) -> tuple[str, str]:
     # Result to tuple of ligand names
-    nm = list(result['unit_results'].values())[0]['name']
+    try:
+        nm = list(result['unit_results'].values())[0]['name']
+    except KeyError as err:
+        print("Error reading 'unit_results' key")
+        print(f"Keys in json: {result.keys()=}")
+        raise err
+
     toks = nm.split()
     if toks[2] == 'repeat':
         return toks[0], toks[1]
@@ -23,7 +29,7 @@ def get_names(result) -> tuple[str, str]:
     type=click.Path(dir_okay=True, file_okay=False, path_type=pathlib.Path),
     default=pathlib.Path('results_0'),
     required=True,
-    help=("Path to the directory that contains all result json files " 
+    help=("Path to the directory that contains all result json files "
           "for repeat 0, default: results_0."),
 )
 @click.option(
@@ -31,7 +37,7 @@ def get_names(result) -> tuple[str, str]:
     type=click.Path(dir_okay=True, file_okay=False, path_type=pathlib.Path),
     default=pathlib.Path('results_1'),
     required=True,
-    help=("Path to the directory that contains all result json files " 
+    help=("Path to the directory that contains all result json files "
           "for repeat 1, default: results_1."),
 )
 @click.option(
@@ -39,7 +45,7 @@ def get_names(result) -> tuple[str, str]:
     type=click.Path(dir_okay=True, file_okay=False, path_type=pathlib.Path),
     default=pathlib.Path('results_2'),
     required=True,
-    help=("Path to the directory that contains all result json files " 
+    help=("Path to the directory that contains all result json files "
           "for repeat 2, default: results_2."),
 )
 @click.option(
@@ -79,6 +85,7 @@ def extract(results_0, results_1, results_2, output):
     edges_dict = dict()
     for file in files_0:
         json_0 = json.load(open(file, 'r'), cls=JSON_HANDLER.decoder)
+        print(f"Reading {file}")
         runtype = file.split('/')[1].split('_')[-2]
         molA, molB = get_names(json_0)
         edge_name = f'edge_{molA}_{molB}'


### PR DESCRIPTION
We now print the JSON file we are currently reading and also print the keys that exist in the JSON file if we have a key error, this will help us figure out if we are reading a results json or an input json as well as help us see if the key error is due to the results missing because the simulation failed.

<!--
Thank you for opening a contribution to the OpenFE 2024 industry benchmark repository.
Below are a few things we ask you to kindly fill in and self-check before we
can accept your contribution. Please ignore any irrelevant sections.
-->

## Input submission checklist

<!--
If you are submitting prepared input files please indicate if you have
done the following:
-->

* [ ] created a directory for each system based on the [template directory][templates]
* [ ] named and placed the directory with the following pattern: `input_structures/prepared_structures/<set_name>/<system_name>`

For each submitted directory:

* [ ] filled in system preparation details in the `PREPARATION_DETAILS.md` file
* [ ] added a PDB file with the protein named `protein.pdb`
* [ ] removed any cofactors from the PDB file and placed them in `cofactors.sdf`
* [ ] did not re-protonate the residues, but left protonation state of the protein unchanged
* [ ] kept cystallographic waters and metals in the PDB file
* [ ] tested the PDB and, if available, cofactors.sdf file using the [input validation script][input_validation]
* [ ] copied over the ligands SDF file to a file named `ligands.sdf` and removed any duplicate binding modes or protonation states, keeping the more favorable state

<!--
Here please add a summary of what changes you have made
-->
## Summary of changes

<!--
Also please indicate that you are happy to release these materials under the
combined MIT and CCBY-SA 4.0 licenses of this repository
-->
## Licensing agreement
* [ ] I agree to release these inputs under the combined MIT and CCBY SA 4.0 licenses of this repository

[templates]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks
[input_validation]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks/utils/input_validation.py
