### PR TITLE
Fix/key error in extract results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,36 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+# Created by https://www.toptal.com/developers/gitignore/api/osx
+# Edit at https://www.toptal.com/developers/gitignore?templates=osx
+
+### OSX ###
+# General
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk
+
+# End of https://www.toptal.com/developers/gitignore/api/osx

--- a/industry_benchmarks/utils/extras/extract_results.py
+++ b/industry_benchmarks/utils/extras/extract_results.py
@@ -43,7 +43,7 @@ def load_results(f):
     # path to deserialized results
     with open(f, 'r') as fd:
         result = json.load(fd, cls=JSON_HANDLER.decoder)
-    if result['estimate'] is None or result['uncertainty'] is None:
+    if result.get('estimate') is None or result.get('uncertainty') is None:
         # Keeping this check so if we do hit an error somehow, we print the traceback
         click.echo(f"Calculations for {f} did not finish successfully!")
         proto_failures = [k for k in result["unit_results"].keys() if k.startswith("ProtocolUnitFailure")]
@@ -121,7 +121,7 @@ def extract(results_0, results_1, results_2, output):
     for file in tqdm(files_0 + files_1 + files_2):
         with open(file, 'r') as fd:
             result = json.load(fd, cls=JSON_HANDLER.decoder)
-        if result['estimate'] is None or result['uncertainty'] is None:
+        if result.get('estimate') is None or result.get('uncertainty') is None:
             has_errors = True
             click.echo(f"Calculations for {file} did not finish successfully!")
             proto_failures = [k for k in result["unit_results"].keys() if k.startswith("ProtocolUnitFailure")]


### PR DESCRIPTION
<!--
Thank you for opening a contribution to the OpenFE 2024 industry benchmark repository.
Below are a few things we ask you to kindly fill in and self-check before we
can accept your contribution. Please ignore any irrelevant sections.
-->

## Input submission checklist

<!--
If you are submitting prepared input files please indicate if you have
done the following:
-->

* [ ] created a directory for each system based on the [template directory][templates]
* [ ] named and placed the directory with the following pattern: `input_structures/prepared_structures/<set_name>/<system_name>`

For each submitted directory:

* [ ] filled in system preparation details in the `PREPARATION_DETAILS.md` file
* [ ] added a PDB file with the protein named `protein.pdb`
* [ ] removed any cofactors from the PDB file and placed them in `cofactors.sdf`
* [ ] did not re-protonate the residues, but left protonation state of the protein unchanged
* [ ] kept cystallographic waters and metals in the PDB file
* [ ] tested the PDB and, if available, cofactors.sdf file using the [input validation script][input_validation]
* [ ] copied over the ligands SDF file to a file named `ligands.sdf` and removed any duplicate binding modes or protonation states, keeping the more favorable state

<!--
Here please add a summary of what changes you have made
-->
## Summary of changes

<!--
Also please indicate that you are happy to release these materials under the
combined MIT and CCBY-SA 4.0 licenses of this repository
-->
## Licensing agreement
* [ ] I agree to release these inputs under the combined MIT and CCBY SA 4.0 licenses of this repository

[templates]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks
[input_validation]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks/utils/input_validation.py
