### PR TITLE
Move FAQ

### DIFF
--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -65,6 +65,7 @@ We thank the OpenFE industry partners for their participation, guidance, and fun
    ./public/overview
    ./private/overview
    get-in-touch
+   prep_and_debug
 
 
 .. toctree::

--- a/docs/source/prep_and_debug.rst
+++ b/docs/source/prep_and_debug.rst
@@ -6,7 +6,8 @@ FAQ: Preparing and Debugging OpenFE Simulations
 
 This FAQ contains a list of issues you may encounter when preparing and
 running simulations with OpenFE. This list will be updated as feedback
-is provided by benchmark partners.
+is provided by benchmark partners. If you find your issue is not currently addressed then please raise an issue on
+the `industry benchmarking repository <https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/issues>`_.
 
 
 1. Ligand Alignment
@@ -16,7 +17,7 @@ Ligands in a series should be pre-aligned when passed to OpenFE tools.
 This means that regions of the ligand that should be part of a common
 core, should have the same coordinates.
 
-In these benchmarks we will use the Kartograf atom mapper. Any ligand
+In these benchmarks we will use the `Kartograf atom mapper <https://kartograf.readthedocs.io/en/latest/index.html>`_. Any ligand
 regions which do not align in 3D space will be unmapped and treated
 as unique atoms in the alchemical topology.
 

--- a/docs/source/private/overview.rst
+++ b/docs/source/private/overview.rst
@@ -131,13 +131,6 @@ To help you, we have created a :ref:`preparing and debugging simulations FAQ <pr
 some common issues you may encounter.
 
 
-.. toctree::
-   :maxdepth: 1
-   :hidden:
-
-   prep_and_debug
-
-
 Cleaning Results
 ================
 


### PR DESCRIPTION
## Summary of changes
Fixes #174 by moving the FAQ page to the front of the docs. I have also added information to direct new issues to this github. 

<!--
Also please indicate that you are happy to release these materials under the
combined MIT and CCBY-SA 4.0 licenses of this repository
-->
## Licensing agreement
* [x] I agree to release these inputs under the combined MIT and CCBY SA 4.0 licenses of this repository

[templates]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks
[input_validation]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks/utils/input_validation.py
