### PR TITLE
Fudge fix for the zero error case

### DIFF
--- a/industry_benchmarks/utils/extras/plot_results.py
+++ b/industry_benchmarks/utils/extras/plot_results.py
@@ -5,6 +5,7 @@ from cinnabar import Measurement, ReferenceState, FEMap
 from cinnabar import plotting as cinnabar_plotting
 from openff.units import unit
 import numpy as np
+import warnings
 
 
 def get_exp_data(filename: Path) -> dict[str, dict[str, float]]:
@@ -79,6 +80,7 @@ def get_calc_data(filename: Path) -> dict[str, dict[str, float]]:
             calculated_data[tag]['ddG_err'] = float(row[3])
             # Special case for when you have a near zero error
             if calculated_data[tag]['ddG_err'] < 0.01:
+                warnings.warn(f"Calculated standard deviation for {tag} is less than 0.01 - adding 0.01 padding")
                 calculated_data[tag]['ddG_err'] += 0.01
 
     return calculated_data

--- a/industry_benchmarks/utils/extras/plot_results.py
+++ b/industry_benchmarks/utils/extras/plot_results.py
@@ -77,6 +77,9 @@ def get_calc_data(filename: Path) -> dict[str, dict[str, float]]:
             calculated_data[tag]['ligand_j'] = row[1]
             calculated_data[tag]['ddG'] = float(row[2])
             calculated_data[tag]['ddG_err'] = float(row[3])
+            # Special case for when you have a near zero error
+            if calculated_data[tag]['ddG_err'] < 0.01:
+                calculated_data[tag]['ddG_err'] += 0.01
 
     return calculated_data
 


### PR DESCRIPTION
<!--
Thank you for opening a contribution to the OpenFE 2024 industry benchmark repository.
Below are a few things we ask you to kindly fill in and self-check before we
can accept your contribution. Please ignore any irrelevant sections.
-->

## Input submission checklist

<!--
If you are submitting prepared input files please indicate if you have
done the following:
-->

* [ ] created a directory for each system based on the [template directory][templates]
* [ ] named and placed the directory with the following pattern: `input_structures/prepared_structures/<set_name>/<system_name>`

For each submitted directory:

* [ ] filled in system preparation details in the `PREPARATION_DETAILS.md` file
* [ ] added a PDB file with the protein named `protein.pdb`
* [ ] removed any cofactors from the PDB file and placed them in `cofactors.sdf`
* [ ] did not re-protonate the residues, but left protonation state of the protein unchanged
* [ ] kept cystallographic waters and metals in the PDB file
* [ ] tested the PDB and, if available, cofactors.sdf file using the [input validation script][input_validation]
* [ ] copied over the ligands SDF file to a file named `ligands.sdf` and removed any duplicate binding modes or protonation states, keeping the more favorable state

<!--
Here please add a summary of what changes you have made
-->
## Summary of changes

<!--
Also please indicate that you are happy to release these materials under the
combined MIT and CCBY-SA 4.0 licenses of this repository
-->
## Licensing agreement
* [x] I agree to release these inputs under the combined MIT and CCBY SA 4.0 licenses of this repository

[templates]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks
[input_validation]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks/utils/input_validation.py
