### PR TITLE
Store numpy data in text files

### DIFF
--- a/industry_benchmarks/utils/data_gathering.py
+++ b/industry_benchmarks/utils/data_gathering.py
@@ -15,6 +15,7 @@ from kartograf.atom_mapping_scorer import (
     MappingRMSDScorer, MappingShapeOverlapScorer, MappingVolumeRatioScorer,
 )
 import shutil
+import numpy as np
 from openff.units import unit
 
 # define all the result files we want to collect
@@ -790,7 +791,15 @@ def process_results(results_folders: list[pathlib.Path], output_dir: pathlib.Pat
                 target_file = results_dir.joinpath(f_name)
                 # we have already done error handling so just try and move files which are present
                 if target_file.exists():
-                    shutil.copy(target_file, output_path.joinpath(f_name))
+                    # we need to convert the npz files to readable txt files for approval
+                    if ".npz" in f_name:
+                        # load the data
+                        data = np.load(target_file)
+                        for key, value in data.items():
+                            # transpose the matrix to have 11 columns for better readability
+                            np.savetxt(output_path.joinpath(f"{key}.txt"), value.T)
+                    else:
+                        shutil.copy(target_file, output_path.joinpath(f_name))
 
 
     return estimates

--- a/industry_benchmarks/utils/tests/test_data_gathering.py
+++ b/industry_benchmarks/utils/tests/test_data_gathering.py
@@ -480,8 +480,12 @@ class TestScript:
                 assert edge_folder.exists()
                 # check the files were moved to the directory
                 for f_name in [
-                    "structural_analysis_data.npz",
-                    "energy_replica_state.npz",
+                    "energy.txt",
+                    "ligand_RMSD.txt",
+                    "ligand_wander.txt",
+                    "protein_2D_RMSD.txt",
+                    "protein_RMSD.txt",
+                    "time_ps.txt",
                     "simulation_real_time_analysis.yaml",
                     "info.yaml"
                 ]:
@@ -562,8 +566,12 @@ class TestScript:
                 assert edge_folder.exists()
                 # check the files were moved to the directory
                 for f_name in [
-                    "structural_analysis_data.npz",
-                    "energy_replica_state.npz",
+                    "energy.txt",
+                    "ligand_RMSD.txt",
+                    "ligand_wander.txt",
+                    "protein_2D_RMSD.txt",
+                    "protein_RMSD.txt",
+                    "time_ps.txt",
                     "simulation_real_time_analysis.yaml",
                     "info.yaml"
                 ]:
@@ -643,8 +651,12 @@ class TestScript:
                     assert edge_folder.exists()
                     # check the files were moved to the directory
                     for f_name in [
-                        "structural_analysis_data.npz",
-                        "energy_replica_state.npz",
+                        "energy.txt",
+                        "ligand_RMSD.txt",
+                        "ligand_wander.txt",
+                        "protein_2D_RMSD.txt",
+                        "protein_RMSD.txt",
+                        "time_ps.txt",
                         "simulation_real_time_analysis.yaml",
                         "info.yaml"
                     ]:


### PR DESCRIPTION
## Summary of changes
All data in the compressed numpy files is now stored in individual text files to help the partners check the contents of the data they share. 

<!--
Also please indicate that you are happy to release these materials under the
combined MIT and CCBY-SA 4.0 licenses of this repository
-->
## Licensing agreement
* [x] I agree to release these inputs under the combined MIT and CCBY SA 4.0 licenses of this repository

[templates]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks
[input_validation]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks/utils/input_validation.py
