### PR TITLE
Don't fail if not all units are ProtocolResultFailures

### DIFF
--- a/industry_benchmarks/utils/fix_networks.py
+++ b/industry_benchmarks/utils/fix_networks.py
@@ -52,7 +52,7 @@ def _get_check_results_json(filename: str) -> None | dict:
     if "unit_results" not in ru.keys():
         print(f"{filename} has no unit results - likely a failure")
         return None
-    if any('exception' in u for u in ru['unit_results'].values()):
+    if all('exception' in u for u in ru['unit_results'].values()):
         print(f"{filename} is a failed simulation")
         return None
 

--- a/industry_benchmarks/utils/tests/test_fix_networks.py
+++ b/industry_benchmarks/utils/tests/test_fix_networks.py
@@ -97,6 +97,11 @@ def complete_cmet_results():
     with resources.files("utils.tests.data") as d:
         yield glob.glob(f"{str(d)}/cmet_results/results_[0-9]/*json")
 
+@pytest.fixture
+def cmet_failure_results():
+    with resources.files("utils.tests.data.cmet_results") as d:
+        yield glob.glob(f"{str(d)}/results_[0-9]_failed_edge/*json")
+
 
 @pytest.fixture
 def cmet_network():
@@ -230,9 +235,10 @@ class TestScript:
 
 
 
-    def test_detect_failed_simulation(self, cmet_network, complete_cmet_results, capsys):
+    def test_detect_failed_simulation(self, cmet_network, cmet_failure_results, capsys):
         """Make sure a message is printed when a simulation fails."""
-        command = f"--input_alchem_network_file {cmet_network} --output_extra_transformations ./ --result_files {' '.join(complete_cmet_results)}"
+        print(cmet_failure_results)
+        command = f"--input_alchem_network_file {cmet_network} --output_extra_transformations ./ --result_files {' '.join(cmet_failure_results)}"
         with pytest.raises(ValueError, match="Too few transformations found for solvent_lig_CHEMBL3402745_200_5_lig_CHEMBL3402744_300_4"):
             cli_fix_network(shlex.split(command))
         assert "lig_CHEMBL3402745_200_5_solvent_lig_CHEMBL3402744_300_4_solvent_solvent.json is a failed simulation" in capsys.readouterr().out

--- a/industry_benchmarks/utils/tests/test_fix_networks.py
+++ b/industry_benchmarks/utils/tests/test_fix_networks.py
@@ -237,7 +237,6 @@ class TestScript:
 
     def test_detect_failed_simulation(self, cmet_network, cmet_failure_results, capsys):
         """Make sure a message is printed when a simulation fails."""
-        print(cmet_failure_results)
         command = f"--input_alchem_network_file {cmet_network} --output_extra_transformations ./ --result_files {' '.join(cmet_failure_results)}"
         with pytest.raises(ValueError, match="Too few transformations found for solvent_lig_CHEMBL3402745_200_5_lig_CHEMBL3402744_300_4"):
             cli_fix_network(shlex.split(command))


### PR DESCRIPTION
<!--
Thank you for opening a contribution to the OpenFE 2024 industry benchmark repository.
Below are a few things we ask you to kindly fill in and self-check before we
can accept your contribution. Please ignore any irrelevant sections.
-->

## Input submission checklist

<!--
If you are submitting prepared input files please indicate if you have
done the following:
-->

* [ ] created a directory for each system based on the [template directory][templates]
* [ ] named and placed the directory with the following pattern: `input_structures/prepared_structures/<set_name>/<system_name>`

For each submitted directory:

* [ ] filled in system preparation details in the `PREPARATION_DETAILS.md` file
* [ ] added a PDB file with the protein named `protein.pdb`
* [ ] removed any cofactors from the PDB file and placed them in `cofactors.sdf`
* [ ] did not re-protonate the residues, but left protonation state of the protein unchanged
* [ ] kept cystallographic waters and metals in the PDB file
* [ ] tested the PDB and, if available, cofactors.sdf file using the [input validation script][input_validation]
* [ ] copied over the ligands SDF file to a file named `ligands.sdf` and removed any duplicate binding modes or protonation states, keeping the more favorable state

<!--
Here please add a summary of what changes you have made
-->
## Summary of changes

<!--
Also please indicate that you are happy to release these materials under the
combined MIT and CCBY-SA 4.0 licenses of this repository
-->
## Licensing agreement
* [x] I agree to release these inputs under the combined MIT and CCBY SA 4.0 licenses of this repository

[templates]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks
[input_validation]: https://github.com/OpenFreeEnergy/IndustryBenchmarks2024/tree/main/industry_benchmarks/utils/input_validation.py
